### PR TITLE
Quitar de la documentación para los comprobantes resumidos la sección "ConfiguracionRepresentacionImpresa"

### DIFF
--- a/EntidadComunicacionBaja/ComunicacionBaja.md
+++ b/EntidadComunicacionBaja/ComunicacionBaja.md
@@ -9,4 +9,3 @@
 | **DetalleComunicacionBaja**  <br>`obligatorio`  <br>`array` | Datos de los detalles o ítems de la Comunicación de Baja.  <br>[[Ver entidad]](../EntidadComunicacionBaja/ComunicacionBajaDetalle.md) | Mínimo de ítems: 1.  <br>Máximo de ítems: 100. |
 | **Correo**  <br>`opcional`  <br>`string` | Correo electrónico al cual le llegará el CDR del CPE. | Se puede enviar una lista de correos utilizando el separador punto y coma (\;) |
 | **InformacionAdicional**  <br>`opcional`  <br>`array` | Información adicional.  <br>[[Ver entidad]](../Entidad/InformacionAdicional.md) | De consignarse esta sección, debe tener como máximo 100 elementos. |
-| **ConfiguracionRepresentacionImpresa**  <br>`opcional`  <br>`object`  | Configuración para la representación impresa.  <br>[[Ver entidad]](../Entidad/ConfiguracionRepresentacionImpresa.md)  | Este campo se utiliza únicamente para los comercios que han contratado un formato adicional personalizado en inglés. |

--- a/EntidadResumenDiario/ResumenDiario.md
+++ b/EntidadResumenDiario/ResumenDiario.md
@@ -9,4 +9,3 @@
 | **DetalleResumenDiario**  <br>`obligatorio`  <br>`array` | Datos de los detalles o ítems del Resumen Diario.  <br>[[Ver entidad]](../EntidadResumenDiario/ResumenDiarioDetalle.md) | Mínimo de ítems: 1.  <br>Máximo de ítems: 100. |
 | **Correo**  <br>`opcional`  <br>`string` | Correo electrónico al cual le llegará el CDR del CPE. | Se puede enviar una lista de correos utilizando el separador punto y coma (\;) |
 | **InformacionAdicional**  <br>`opcional`  <br>`array` | Información adicional.  <br>[[Ver entidad]](../Entidad/InformacionAdicional.md) | De consignarse esta sección, debe tener como máximo 100 elementos. |
-| **ConfiguracionRepresentacionImpresa**  <br>`opcional`  <br>`object`  | Configuración para la representación impresa.  <br>[[Ver entidad]](../Entidad/ConfiguracionRepresentacionImpresa.md)  | Este campo se utiliza únicamente para los comercios que han contratado un formato adicional personalizado en inglés. |

--- a/EntidadResumenReversion/ResumenReversion.md
+++ b/EntidadResumenReversion/ResumenReversion.md
@@ -9,4 +9,3 @@
 | **DetalleResumenReversion**  <br>`obligatorio`  <br>`array` | Datos de los detalles o ítems del Resumen de Reversión.  <br>[[Ver entidad]](../EntidadResumenReversion/ResumenReversionDetalle.md) | Mínimo de ítems: 1.  <br>Máximo de ítems: 100. |
 | **Correo**  <br>`opcional`  <br>`string` | Correo electrónico al cual le llegará el CDR del CPE. | Se puede enviar una lista de correos utilizando el separador punto y coma (\;) |
 | **InformacionAdicional**  <br>`opcional`  <br>`array` | Información adicional.  <br>[[Ver entidad]](../Entidad/InformacionAdicional.md) | De consignarse esta sección, debe tener como máximo 100 elementos. |
-| **ConfiguracionRepresentacionImpresa**  <br>`opcional`  <br>`object`  | Configuración para la representación impresa.  <br>[[Ver entidad]](../Entidad/ConfiguracionRepresentacionImpresa.md)  | Este campo se utiliza únicamente para los comercios que han contratado un formato adicional personalizado en inglés. |


### PR DESCRIPTION
Quitar de la documentación para los comprobantes resumidos la sección "ConfiguracionRepresentacionImpresa", ya que esta es exclusiva de los comprobantes individuales.